### PR TITLE
Remove Google Analytics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,7 @@
         </p>
       </div>
       <div class="col-lg-8">
-        <img class="screenshot img-fluid mx-auto d-block" src="images/screenshot.png" srcset="images/screenshot@2x.png 2x" alt="screenshot of the Chrome DevTools">
+        <img class="screenshot img-fluid mx-auto d-block" src="/images/screenshot.png" srcset="/images/screenshot@2x.png 2x" alt="screenshot of the Chrome DevTools">
       </div>
     </div>
     <div class="row border-top pt-4">
@@ -104,13 +104,6 @@
             <a class="btn btn-primary" href="https://github.com/sponsors/NickCarneiro">
               Contribute Now
             </a>
-          </div>
-        </div>
-        <div class="row d-none d-sm-block">
-          <h3>Found a problem?</h3>
-          <div>
-            Please report bugs
-            <a href="https://github.com/curlconverter/curlconverter/issues/new">on GitHub</a>.
           </div>
         </div>
       </div>
@@ -131,34 +124,22 @@
       <div class="col-sm-4">
         <h3>Privacy</h3>
         <p>
-          <code>curlconverter</code> is <a href="https://github.com/curlconverter/curlconverter">open source</a> and runs <a href="https://github.com/curlconverter/curltorequests/blob/master/index.js">entirely in your browser</a> using JavaScript.
           We do <b>not</b> transmit or record the curl commands you enter or what they're converted to.
         <p>
         </p>
-          We only record which languages you're converting to and whether or not the conversions succeed (through <a href="https://en.wikipedia.org/wiki/Google_Analytics">Google Analytics</a>).
+          This is a static website (hosted on <a href="https://pages.github.com/">GitHub Pages</a>) that runs <a href="https://github.com/curlconverter/curltorequests/blob/master/index.js">entirely in your browser</a>.
         </p>
-      </div>
-    </div>
-    <div class="row d-block d-sm-none">
-      <h3>Found a problem?</h3>
-      <div>
-        Please report bugs
-        <a href="https://github.com/curlconverter/curlconverter/issues/new">on GitHub</a>.
+        <h3>Found a problem?</h3>
+        <div>
+          Please report bugs
+          <a href="https://github.com/curlconverter/curlconverter/issues/new">on GitHub</a>.
+        </div>
       </div>
     </div>
   </div>
 
   <a class="github-fork-ribbon right-top" href="https://github.com/curlconverter/curlconverter" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
 
-  <script src="main.js"></script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-7363929-21', 'auto');
-    ga('send', 'pageview');
-  </script>
+  <script src="/main.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         </p>
       </div>
       <div class="col-lg-8">
-        <img class="screenshot img-fluid mx-auto d-block" src="images/screenshot.png" srcset="images/screenshot@2x.png 2x" alt="screenshot of the Chrome DevTools">
+        <img class="screenshot img-fluid mx-auto d-block" src="/images/screenshot.png" srcset="/images/screenshot@2x.png 2x" alt="screenshot of the Chrome DevTools">
       </div>
     </div>
     <div class="row border-top pt-4">
@@ -104,13 +104,6 @@
             <a class="btn btn-primary" href="https://github.com/sponsors/NickCarneiro">
               Contribute Now
             </a>
-          </div>
-        </div>
-        <div class="row d-none d-sm-block">
-          <h3>Found a problem?</h3>
-          <div>
-            Please report bugs
-            <a href="https://github.com/curlconverter/curlconverter/issues/new">on GitHub</a>.
           </div>
         </div>
       </div>
@@ -131,34 +124,22 @@
       <div class="col-sm-4">
         <h3>Privacy</h3>
         <p>
-          <code>curlconverter</code> is <a href="https://github.com/curlconverter/curlconverter">open source</a> and runs <a href="https://github.com/curlconverter/curltorequests/blob/master/index.js">entirely in your browser</a> using JavaScript.
           We do <b>not</b> transmit or record the curl commands you enter or what they're converted to.
         <p>
         </p>
-          We only record which languages you're converting to and whether or not the conversions succeed (through <a href="https://en.wikipedia.org/wiki/Google_Analytics">Google Analytics</a>).
+          This is a static website (hosted on <a href="https://pages.github.com/">GitHub Pages</a>) that runs <a href="https://github.com/curlconverter/curltorequests/blob/master/index.js">entirely in your browser</a>.
         </p>
-      </div>
-    </div>
-    <div class="row d-block d-sm-none">
-      <h3>Found a problem?</h3>
-      <div>
-        Please report bugs
-        <a href="https://github.com/curlconverter/curlconverter/issues/new">on GitHub</a>.
+        <h3>Found a problem?</h3>
+        <div>
+          Please report bugs
+          <a href="https://github.com/curlconverter/curlconverter/issues/new">on GitHub</a>.
+        </div>
       </div>
     </div>
   </div>
 
   <a class="github-fork-ribbon right-top" href="https://github.com/curlconverter/curlconverter" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
 
-  <script src="main.js"></script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-7363929-21', 'auto');
-    ga('send', 'pageview');
-  </script>
+  <script src="/main.js"></script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -9,17 +9,20 @@ import * as curlconverter from 'curlconverter'
 
 import './main.css'
 
-// TODO: put the curl input in the URL?
 // TODO: include a Windows screenshot. Firefox and Safari have "copy as cURL" as well
-// TODO: option to pre-fill new GitHub Issue with input (and output?) when clicking "create an issue"
+//
+// TODO: put the curl input in the URL?
 // TODO: print a diff of the raw resulting requests?
 
-// TODO: initial input should be "curl example.com"
-// with the corresponding output but greyed out?
+// TODO: translate the site. The top languages are
+// chinese
+// russian
+// portuguese
+// japanese
+// korean
+// french
+// spanish
 
-// TODO: make all the `language` values work with hljs
-
-// TODO: library names should be links to their homepages (for context)
 const languages = {
   ansible: { converter: curlconverter.toAnsible, name: 'Ansible URI', hljs: 'yaml' },
   browser: { converter: curlconverter.toBrowser, name: 'Browser (fetch)', hljs: 'javascript' },
@@ -129,7 +132,6 @@ const convert = function () {
       generatedCode = converter(curlCode).trimEnd() // remove trailling newline
 
       const event = converter.name.toLowerCase().replace('tojsonstring', 'tojson')
-      window.ga('send', 'event', 'convertcode', event)
 
       hideIssuePromo()
     } catch (e) {
@@ -142,7 +144,6 @@ const convert = function () {
         error += ':\n' + origErrorMsg
       }
       changeHighlight('plaintext')
-      window.ga('send', 'event', 'convertcode', 'parseerror')
       showIssuePromo(origErrorMsg)
     }
   }


### PR DESCRIPTION
because it's easier if we don't have to explain what's being logged (the language being converted to and whether the conversion failed) and why users (who might be pasting sensitive requests) should be okay with it.