### PR TITLE
Rename "Browser (fetch)" to "JavaScript"

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,11 +61,11 @@
           <div class="col col-sm-auto px-sm-0">
             <select class="form-select form-select-lg" id="language">
               <option value="ansible">Ansible</option>
-              <option value="browser">Browser (fetch)</option>
               <option value="dart">Dart</option>
               <option value="elixir">Elixir</option>
               <option value="go">Go</option>
               <option value="java">Java</option>
+              <option value="javascript">JavaScript</option>
               <option value="json">JSON</option>
               <option value="node-fetch">Node.js (fetch)</option>
               <option value="node-request">Node.js (request)</option>

--- a/index.js
+++ b/index.js
@@ -27,11 +27,11 @@ import * as curlconverter from 'curlconverter'
 
 const languages = {
   ansible: { converter: curlconverter.toAnsible, name: 'Ansible URI', hljs: 'yaml' },
-  browser: { converter: curlconverter.toBrowser, name: 'Browser (fetch)', hljs: 'javascript' },
   dart: { converter: curlconverter.toDart, name: 'Dart', hljs: 'dart' },
   elixir: { converter: curlconverter.toElixir, name: 'Elixir', hljs: 'elixir' },
   go: { converter: curlconverter.toGo, name: 'Go', hljs: 'go' },
   java: { converter: curlconverter.toJava, name: 'Java', hljs: 'java' },
+  javascript: { converter: curlconverter.toBrowser, name: 'JavaScript', hljs: 'javascript' },
   json: { converter: curlconverter.toJsonString, name: 'JSON', hljs: 'json' },
   matlab: { converter: curlconverter.toMATLAB, name: 'MATLAB', hljs: 'matlab' },
   'node-fetch': { converter: curlconverter.toNodeFetch, name: 'Node (fetch)', hljs: 'javascript' },


### PR DESCRIPTION
because people quickly scan for "JavaScript", don't see it and assume we don't support it.