### PR TITLE
add mailto link to email devs curl commands that fail to convert

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,8 +142,10 @@
     </div>
     <div class="row">
       <div id="copy-to-clipboard" class="text-end"><a href="#">Copy to clipboard</a></div>
-      <div style="display: none;" id="issue-promo">If your syntax is correct, create a
-        <a href="https://github.com/curlconverter/curlconverter/issues/new" target="_blank">new issue</a> <span style="display: none;" id="prefilled-issue"> or <a href="" target="_blank">prefilled with the current input</a></span>
+      <div style="display: none;" id="issue-promo">If your syntax is correct,
+        open a <a href="https://github.com/curlconverter/curlconverter/issues/new" target="_blank">new issue on GitHub</a>
+        <span id="prefilled-issue">or one <a href="https://github.com/curlconverter/curlconverter/issues/new" target="_blank">prefilled with the current input</a></span>
+        <span id="email-devs">or <a href="mailto:nickc@trillworks.com" target="_blank">email us</a></span>
       </div>
     </div>
 

--- a/index.js
+++ b/index.js
@@ -129,19 +129,37 @@ const showIssuePromo = (errorMsg) => {
   const issuePromo = document.getElementById('issue-promo')
 
   const curlCode = document.getElementById('curl-code').value
+
   const prefilledIssue = document.getElementById('prefilled-issue')
+  const githubA = prefilledIssue.getElementsByTagName('a')[0]
+  const emailDevs = document.getElementById('email-devs')
+  const mailtoA = emailDevs.getElementsByTagName('a')[0]
+
+  const githubLink = new URL('https://github.com/curlconverter/curlconverter/issues/new')
+  const mailtoLink = new URL('mailto:nickc@trillworks.com')
+
   if (errorMsg && curlCode && curlCode.length <= 2000) {
-    const link = new URL('https://github.com/curlconverter/curlconverter/issues/new')
-    const params = new URLSearchParams({
-      title: 'Error: "' + errorMsg + '"',
-      body: '**Input**:\n\n```sh\n' + curlCode + '\n```\n\n**Expected output**:\n\n'
+    if (!curlCode.toLowerCase().includes('cookie') &&
+        !curlCode.toLowerCase().includes('authorization')) {
+      const githubParams = new URLSearchParams({
+        title: 'Error: "' + errorMsg + '"',
+        body: '**Input**:\n\n```sh\n' + curlCode + '\n```\n\n**Expected output**:\n\n'
+      })
+      githubLink.search = githubParams
+      prefilledIssue.style.display = 'inline-block'
+    } else {
+      prefilledIssue.style.display = 'none'
+    }
+
+    const mailtoParams = new URLSearchParams({
+      subject: 'Curlconverter Error: "' + errorMsg + '"',
+      body: 'Input:\n\n' + curlCode + '\n\nExpected output:\n\n'
     })
-    link.search = params
-    prefilledIssue.getElementsByTagName('a')[0].href = link.toString()
-    prefilledIssue.style.display = 'inline-block'
-  } else {
-    prefilledIssue.style.display = 'none'
+    mailtoLink.search = mailtoParams
   }
+
+  githubA.href = githubLink.toString()
+  mailtoA.href = mailtoLink.toString()
 
   issuePromo.style.display = 'inline-block'
 }


### PR DESCRIPTION
<img width="764" alt="Screen Shot 2022-03-21 at 2 21 37 PM" src="https://user-images.githubusercontent.com/5687998/159365927-584b2c16-0508-4a20-9947-8f5c00787384.png">

<img width="515" alt="Screen Shot 2022-03-21 at 2 22 14 PM" src="https://user-images.githubusercontent.com/5687998/159366015-4940f229-8706-4a0a-a801-37d51d409c55.png">

We now have 3 links, one creates a blank github issue, one prefills a new github issue with the current output and now a third one opens an email editing dialog prefilled with the current input. Having a link that prefills a github issue with their input is (hopefully) convenient to users, but the problem is that that because curl commands copied from the browser can contain cookies or other authentication tokens, they're very sensitive data and we do not want people posting their cookies to the public issue tracker. We can't expect them to know what a cookie is and what attackers can do with one, much less to check whether their command has one. Just clicking on the links probably causes github or your email provider to log the request, so now your cookie is stored in github's or gmail's logs, which isn't ideal.

The link to a prefilled github issue is hidden if the word "cookie" or "authorization" appears, that way users will have to do some extra work (manually copy it) if their curl command contains sensitive data, which will still probably happen but at least it's not totally our fault now and they have the option to privately email us the command in case they're aware that this is a consideration.

I think ideally we should have a pop-up that explains the risk to users when you click on the 2nd or 3rd link.

Works on https://github.com/curlconverter/curlconverter/issues/186