### PR TITLE
Install curlconverter from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.5",
     "bootstrap": "^5.1.3",
-    "curlconverter": "git+ssh://git@github.com/curlconverter/curlconverter.git",
+    "curlconverter": "^4.0.0",
     "detect-browser": "^5.3.0",
     "github-fork-ribbon-css": "^0.2.3",
     "highlight.js": "^11.5.1",


### PR DESCRIPTION
so that we can host the site on Cloudflare Pages, whose build environment doesn't have Emscripten or Docker