### PR TITLE
Remove donation call-to-action

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,13 +350,6 @@ response = requests.get('http://example.com')</code></pre>
       </div>
       <div class="col-sm-6 col-md-4">
         <div class="row">
-          <h3>Support Us</h3>
-          <div class="well larger-text pb-3 pb-sm-4">
-            <p>GitHub is matching all contributions to this project on <a href="https://github.com/sponsors/NickCarneiro">GitHub Sponsors</a>.</p>
-            <a class="btn btn-primary" href="https://github.com/sponsors/NickCarneiro">
-              Contribute Now
-            </a>
-          </div>
           <h3>Found a problem?</h3>
           <div>
             Please report bugs


### PR DESCRIPTION
I'm not contributing much so I don't feel like soliciting donations anymore. Moreover, the homepage has gotten a little visually busy and this frees up some real estate.